### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/db_backup.yaml
+++ b/.github/workflows/db_backup.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.1.0
 
-      - uses: szenius/set-timezone@v1.0
+      - uses: szenius/set-timezone@v1.1
         with:
           timezoneLinux: "America/New_York"
 
@@ -28,7 +28,7 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
       - name: Upload backup
-        uses: BetaHuhn/do-spaces-action@v2.0.80
+        uses: BetaHuhn/do-spaces-action@v2.0.83
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY }}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -107,7 +107,7 @@ jobs:
         run: make collectstatic
 
       - name: Upload static files
-        uses: BetaHuhn/do-spaces-action@v2.0.80
+        uses: BetaHuhn/do-spaces-action@v2.0.83
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY }}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[BetaHuhn/do-spaces-action](https://github.com/BetaHuhn/do-spaces-action)** published a new release **[v2.0.83](https://github.com/BetaHuhn/do-spaces-action/releases/tag/v2.0.83)** on 2022-11-28T01:49:08Z
* **[szenius/set-timezone](https://github.com/szenius/set-timezone)** published a new release **[v1.1](https://github.com/szenius/set-timezone/releases/tag/v1.1)** on 2022-11-13T04:58:07Z
