### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -25,7 +25,7 @@ jobs:
       VITE_ADMIN_EMAIL: desecho@gmail.com
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GitHub registry
         uses: docker/login-action@v3.3.0
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Build and push docker backend image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}-backend:latest
@@ -47,7 +47,7 @@ jobs:
           context: .
 
       - name: Build and push docker frontend image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           context: ./frontend
           build-args: |
@@ -80,13 +80,13 @@ jobs:
           # cache-dependency-path: poetry.lock
 
       - name: Use pip cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ~/.cache/pip
           key: pip
 
       - name: Use venv cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: .venv
           key: venv-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/reusable_test.yaml
+++ b/.github/workflows/reusable_test.yaml
@@ -19,7 +19,7 @@ jobs:
           # cache-dependency-path: poetry.lock
 
       - name: Use pip cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ~/.cache/pip
           key: pip
@@ -34,7 +34,7 @@ jobs:
           # cache-dependency-path: frontend/yarn.lock
 
       - name: Use tox cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: .tox
           key: tox-${{ hashFiles('poetry.lock') }}
@@ -44,7 +44,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Use yarn cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('frontend/yarn.lock') }}
@@ -74,4 +74,4 @@ jobs:
         run: make test
 
       - name: Run codecov
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v5.1.2


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.10.0](https://github.com/docker/build-push-action/releases/tag/v6.10.0)** on 2024-11-26T10:49:47Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.1.2](https://github.com/codecov/codecov-action/releases/tag/v5.1.2)** on 2024-12-18T18:45:28Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.0](https://github.com/actions/cache/releases/tag/v4.2.0)** on 2024-12-05T16:45:49Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.8.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.8.0)** on 2024-12-16T09:47:41Z
