### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -25,10 +25,10 @@ jobs:
       VITE_ADMIN_EMAIL: desecho@gmail.com
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@v3.10.0
 
       - name: Login to GitHub registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Build and push docker backend image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.15.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}-backend:latest
@@ -47,7 +47,7 @@ jobs:
           context: .
 
       - name: Build and push docker frontend image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.15.0
         with:
           context: ./frontend
           build-args: |
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: "3.11"
           # This is not working currently. See https://github.com/actions/setup-python/issues/369
@@ -80,13 +80,13 @@ jobs:
           # cache-dependency-path: poetry.lock
 
       - name: Use pip cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.cache/pip
           key: pip
 
       - name: Use venv cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.3
         with:
           path: .venv
           key: venv-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/reusable_test.yaml
+++ b/.github/workflows/reusable_test.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: "3.11"
           # This is not working currently. See https://github.com/actions/setup-python/issues/369
@@ -19,13 +19,13 @@ jobs:
           # cache-dependency-path: poetry.lock
 
       - name: Use pip cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.cache/pip
           key: pip
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
@@ -34,7 +34,7 @@ jobs:
           # cache-dependency-path: frontend/yarn.lock
 
       - name: Use tox cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.3
         with:
           path: .tox
           key: tox-${{ hashFiles('poetry.lock') }}
@@ -44,7 +44,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Use yarn cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('frontend/yarn.lock') }}
@@ -74,4 +74,4 @@ jobs:
         run: make test
 
       - name: Run codecov
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v5.4.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.0](https://github.com/codecov/codecov-action/releases/tag/v5.4.0)** on 2025-02-26T23:41:16Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)** on 2025-03-14T09:53:25Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.15.0](https://github.com/docker/build-push-action/releases/tag/v6.15.0)** on 2025-02-26T15:28:00Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.5.0](https://github.com/actions/setup-python/releases/tag/v5.5.0)** on 2025-03-25T02:43:21Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)** on 2025-02-26T15:36:31Z
