### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Build and push docker backend image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}-backend:latest
@@ -47,7 +47,7 @@ jobs:
           context: .
 
       - name: Build and push docker frontend image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           context: ./frontend
           build-args: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.19.2](https://github.com/docker/build-push-action/releases/tag/v6.19.2)** on 2026-02-12T08:51:07Z
